### PR TITLE
Distance on Polygon dose not calculate minimum distance

### DIFF
--- a/Source/com/watabou/geom/Polygon.hx
+++ b/Source/com/watabou/geom/Polygon.hx
@@ -158,7 +158,10 @@ abstract Polygon(Array<Point>) from Array<Point> to Array<Point> {
 		for (i in 1...this.length) {
 			var v1 = this[i];
 			var d1 = Point.distance( v1, p );
-			if (d1 < d) v0 = v1;
+			if (d1 < d) {
+				v0 = v1;
+				d = d1;
+			}
 		}
 		return d;
 	}


### PR DESCRIPTION
I have zero expiriance with Haxe, so maybe it dose something different to what I think, but to me it seemse to calculate the distance to the first vertex, not the shortest distance to any vertex.

https://github.com/watabou/TownGeneratorOS/blob/7fbc87a9398cc508af24de93f79cf2ad027f352b/Source/com/watabou/geom/Polygon.hx#L153-L164

In the beginning `d` gets calculated with the first vertex, but never updated after that and then returned. Only `v0` is changed, but never readed.

feel free to do what ever you want with this :)